### PR TITLE
Add image.png to README under demo.nb notebook section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ After loading the file, call `?LoadDotEnv` to see the usage string:
 ?LoadDotEnv
 ```
 
+## demo.nb notebook
+
+![demo.nb notebook screenshot](image.png)
+
 ## Limitations
 
 It handles:


### PR DESCRIPTION
Adds a `## demo.nb notebook` section to the README with image.png displayed as a screenshot.

Closes #8

Generated with [Claude Code](https://claude.ai/code)