### PR TITLE
ci: allow git fetch, git pull, and WebFetch in Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,6 +24,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_tools: |
+            Bash(git fetch*)
+            Bash(git pull*)
+            WebFetch
           allowed_bots: 'claude[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,5 +35,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_tools: |
+            Bash(git fetch*)
+            Bash(git pull*)
+            WebFetch
           additional_permissions: |
             actions: read


### PR DESCRIPTION
## Summary
- Adds `allowed_tools` to both `claude.yml` and `claude-code-review.yml` workflows
- Permits `git fetch`, `git pull`, and `WebFetch` so Claude can resolve diverged branches and fetch web content during CI runs

## Test plan
- [ ] Trigger a Claude issue workflow and verify it can fetch/pull without errors
- [ ] Trigger a Claude PR review and verify WebFetch works for reference links

🤖 Generated with [Claude Code](https://claude.com/claude-code)