### PR TITLE
Fix: flatten nested Association returned by ImportString Ini parser

### DIFF
--- a/LoadDotEnv.wl
+++ b/LoadDotEnv.wl
@@ -28,7 +28,8 @@ LoadDotEnv[path_String] := Module[{lines1, lines2, lines3, stripped, content, pa
   stripped = DeleteCases[lines3, line_ /; StringStartsQ[line, "#"]];
   If[stripped === {}, Return[<||>]];
   content = StringRiffle[stripped, "\n"];
-  parsed = ImportString[content, "Ini"]
+  parsed = ImportString[content, "Ini"];
+  Association @@ Flatten[Values[parsed]]
 ]
 
 LoadDotEnv::nofile = "File not found: `1`."


### PR DESCRIPTION
ImportString[..., "Ini"] returns a nested structure grouped by sections. Use `Association @@ Flatten[Values[parsed]]` to return a clean flat Association.

Fixes #19

Generated with [Claude Code](https://claude.ai/code)