### PR TITLE
chore: add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+.DS_Store


### PR DESCRIPTION
## Summary
- Adds `.DS_Store` to `.gitignore` to prevent macOS metadata files from being tracked

## Test plan
- [ ] Verify `.DS_Store` no longer shows in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)