### PR TITLE
Add References section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,10 @@ It handles:
 - Blank lines
 
 Not yet supported: quoted values, multi-line values, variable expansion, the `export` prefix, or UTF-8 BOM stripping.
+
+## References
+
+- [Loading .env files in Wolfram Language — Mathematica Stack Exchange](https://mathematica.stackexchange.com/q/318952/36681)
+- [The .env File Format — dotenv.org](https://www.dotenv.org/docs/security/env.html)
+- [Loading .env files in Wolfram Language — Wolfram Community](https://community.wolfram.com/groups/-/m/t/3653796)
+- [python-dotenv — GitHub](https://github.com/theskumar/python-dotenv)


### PR DESCRIPTION
Adds a References section to README.md with links to Mathematica Stack Exchange, dotenv.org, Wolfram Community, and python-dotenv.

Closes #11

Generated with [Claude Code](https://claude.ai/code)