### PR TITLE
fix: use settings instead of invalid allowed_tools input

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,10 +24,16 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_tools: |
-            Bash(git fetch*)
-            Bash(git pull*)
-            WebFetch
+          settings: |
+            {
+              "permissions": {
+                "allow": [
+                  "Bash(git fetch*)",
+                  "Bash(git pull*)",
+                  "WebFetch"
+                ]
+              }
+            }
           allowed_bots: 'claude[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,9 +35,15 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_tools: |
-            Bash(git fetch*)
-            Bash(git pull*)
-            WebFetch
+          settings: |
+            {
+              "permissions": {
+                "allow": [
+                  "Bash(git fetch*)",
+                  "Bash(git pull*)",
+                  "WebFetch"
+                ]
+              }
+            }
           additional_permissions: |
             actions: read


### PR DESCRIPTION
The allowed_tools parameter is not a valid input for claude-code-action@v1. Use the settings input with a permissions JSON object instead.